### PR TITLE
refactor(countries-flag): adds iso2 and iso3 shortcodes to response

### DIFF
--- a/controllers/countryController.js
+++ b/controllers/countryController.js
@@ -1,7 +1,8 @@
 const CountriesAndCities = require('../model/countriesAndCities')
 const CountriesAndUnicodes = require('../model/countriesAndUnicodes')
 const CountriesAndFlag = require('../model/countriesAndFlag')
-const CountriesAndCodes = require('../model/countriesAndCodes')
+const CountriesAndCodes = require('../model/countriesAndCodes');
+const Finder = require('../helpers/finder');
 const positions = CountriesAndCodes.map(x => ({ name: x.name, long: x.longitude, lat: x.latitude }))
 
 const Respond = require('../helpers/respond');
@@ -125,10 +126,28 @@ class CountryController {
      * @param {Object} res response object
      */
     static getCountriesFlagImages(req, res) {
+
         return res.status(200).json({
             error: false,
             msg: 'flags images retrieved',
-            data: CountriesAndFlag.map(x => ({ name: x.name, flag: x.flag }))
+            // data: CountriesAndFlag.map(x => ({
+            //     name: x.name,
+            //     flag: x.flag,
+            // })),
+            data: CountriesAndFlag.map(x => {
+
+                let code = Finder.findCountryByName(x.name, CountriesAndUnicodes, 'Name')
+
+                const dataObj = {
+                    name: x.name,
+                    flag: x.flag,
+                    Iso2: code ? code.Iso2 : null,
+                    Iso3: code ? code.Iso3 : null,
+                }
+                return dataObj
+                // code: Finder.findCountryByName(x.name, ).
+
+            })
         });
     }
     /**

--- a/helpers/finder.js
+++ b/helpers/finder.js
@@ -1,0 +1,17 @@
+
+class Finder {
+    /**
+     * Due to the inconsistency of naming in the provided data, we need to
+     * specify what param to search by
+     * @param {string} name your query
+     * @param {Array} arr the array to check
+     * @param {param} param the parameter
+     */
+
+    static findCountryByName(name, arr, param) {
+        return arr.find(x => x[`${param}`].toLowerCase() === name.toLowerCase());
+    }
+}
+
+
+module.exports = Finder;

--- a/readme.md
+++ b/readme.md
@@ -392,29 +392,28 @@ OR
   "data": [
     {
       "name": "Afghanistan",
-      "flag": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Flag_of_Afghanistan.svg"
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Flag_of_Afghanistan.svg",
+      "Iso2": "AF",
+      "Iso3": "AFG"
     },
     {
       "name": "Albania",
-      "flag": "https://upload.wikimedia.org/wikipedia/commons/3/36/Flag_of_Albania.svg"
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/3/36/Flag_of_Albania.svg",
+      "Iso2": "AL",
+      "Iso3": "ALB"
     },
     {
       "name": "Algeria",
-      "flag": "https://upload.wikimedia.org/wikipedia/commons/7/77/Flag_of_Algeria.svg"
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/7/77/Flag_of_Algeria.svg",
+      "Iso2": "DZ",
+      "Iso3": "DZA"
     },
     {
       "name": "Andorra",
-      "flag": "https://upload.wikimedia.org/wikipedia/commons/1/19/Flag_of_Andorra.svg"
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/1/19/Flag_of_Andorra.svg",
+      "Iso2": "AD",
+      "Iso3": "AND"
     },
-    {
-      "name": "Angola",
-      "flag": "https://upload.wikimedia.org/wikipedia/commons/9/9d/Flag_of_Angola.svg"
-    },
-    {
-      "name": "Anguilla",
-      "flag": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Flag_of_Anguilla.svg"
-    },
-    ...
 ```
 
 --------------------------------------------------------


### PR DESCRIPTION
- adds iso2 and iso3 shortcodes to response
- response body for `/countries/flag/images` endpoint now contains `iso2` and `iso3` country code

```json
    {
      "name": "Afghanistan",
      "flag": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Flag_of_Afghanistan.svg",
      "Iso2": "AF",
      "Iso3": "AFG"
    },

```
Closes #7 

